### PR TITLE
Documentation / ergonomics (4/n)

### DIFF
--- a/.github/workflows/CommonsZip_Std.S7z.S7zExe.build.yml
+++ b/.github/workflows/CommonsZip_Std.S7z.S7zExe.build.yml
@@ -19,13 +19,11 @@ jobs:
                   path: |
                       target/data/dk/val.1
                       target/data/dk/cts.1.*
-                      xconfig/build.pub
-                      xconfig/build.sec
+                      target/config/dk/build.pub
+                      target/config/dk/build.sec
                   restore-keys: dk-stores-and-keys             # use latest cache
                   key: dk-stores-and-keys-${{ github.run_id }} # update cache on every run
 
-            - name: List xconfig before
-              run: Get-ChildItem -Recurse xconfig
             - name: List target before
               run: Get-ChildItem -Recurse target
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ software "7zip" as an example. (dk has no affliation with 7zip.)
 
 ## Using the Build Tool
 
+> Sorry macOS users, today the build tool `dk0/mlfront-shell` downloads an *unsigned* standalone binary. It will be signed later, once `dk0` is merged into `dk`. Your mac probably won't like it. If you are adventurous, you can run `xattr -d com.apple.quarantine ~/.local/share/mlfront-shell/mlfrontshellexe-2.4.*-darwin_arm64/mlfront-shell` and try again.
+
 <!-- $MDX skip -->
 ```sh
 # this is not working yet, but it is close!

--- a/mlfront-shell
+++ b/mlfront-shell
@@ -23,14 +23,14 @@ set -euf
 
 # Update within dksdk-coder:
 #   f_mlfrontshell() { ver=$1; install -d build; for i in darwin_arm64 darwin_x86_64 linux_x86 linux_x86_64 windows_x86_64 windows_x86; do extexe=; case $i in windows_*) extexe=.exe ;; esac; curl -Lo "build/mlfrontshell-$i" "https://gitlab.com/api/v4/projects/60486861/packages/generic/shell/$ver/mlfront-shell-$i$extexe"; done }
-#   f_mlfrontshell 2.4.2.6
+#   f_mlfrontshell 2.4.2.7
 #   shasum -a 256 build/mlfrontshell-* | awk 'BEGIN{FS="[ /-]"} {printf "cksum256_%s=%s\n", $5, $1}' | sort
 # -------------------------------------
-majminpat_ver=2.4.2.6
-cksum256_darwin_arm64=b241b04cdcd8b14a4b6a88a1e2918e44b462e62feec65823da0f03dc4902ffdd
-cksum256_darwin_x86_64=93df4b486ccaf49fc8ea314f4a1ea52644c310c91e8989271e3f4d153a9e7c7f
-cksum256_linux_x86_64=23f126ba333b5fb26c385fadcd7d48153abbff249c723993bbee128b16dda2c8
-cksum256_linux_x86=f4f2e157ee5fc1987d429a0429eae4789d8bcba5b80e17f3de266aea6e858bb1
+majminpat_ver=2.4.2.7
+cksum256_darwin_arm64=870090b6ad87e27bbde01914e09c5f531ad540b895c4eaa8ea835f3180d33afc
+cksum256_darwin_x86_64=17ac41ff891ad8699128f21193b5d6447cb1a57b970ff69c72f56fdfd93e6ff3
+cksum256_linux_x86_64=3d626241db888725cfc6676b3d0c04680c46ef63dba33e66a4e1564ea6d1eae2
+cksum256_linux_x86=94e54228b5f26741fc6907016a0769333012b72841ad0e9c23eb355a2e2a71ec
 
 dk_pwd=$PWD
 

--- a/mlfront-shell.cmd
+++ b/mlfront-shell.cmd
@@ -41,14 +41,14 @@ SET DKCODER_PWD=%CD%
 
 REM Update within dksdk-coder:
 REM   f_mlfrontshell() { ver=$1; install -d build; for i in darwin_arm64 darwin_x86_64 linux_x86 linux_x86_64 windows_x86_64 windows_x86; do extexe=; case $i in windows_*) extexe=.exe ;; esac; curl -Lo "build/mlfrontshell-$i" "https://gitlab.com/api/v4/projects/60486861/packages/generic/shell/$ver/mlfront-shell-$i$extexe"; done }
-REM   f_mlfrontshell 2.4.2.6
+REM   f_mlfrontshell 2.4.2.7
 REM   shasum -a 256 build/mlfrontshell-* | awk 'BEGIN{FS="[ /-]"} {printf "SET DK_CKSUM_%s=%s\n", toupper($5), $1}' |  sort
 REM
 REM   Empty value if the architecture is not supported.
 REM -------------------------------------
-SET DK_VER=2.4.2.6
-SET DK_CKSUM_WINDOWS_X86_64=8c45a07ca019cdd5177a6690067379b7911dc40b63ee110eac547cab47e3cbf4
-SET DK_CKSUM_WINDOWS_X86=cdefa8393117a65f0c7b4c573ca9b79f66cef53dce8cdb39d4a451828df0ce63
+SET DK_VER=2.4.2.7
+SET DK_CKSUM_WINDOWS_X86_64=d46ea745523f63b0d49500ce4e6fdf305ecae752159adc4e554e8bb2c5c445b8
+SET DK_CKSUM_WINDOWS_X86=0367c6cd5e353758f58b3549e2bc3c360b0b830eba42137510fbcfbfb02f6bdd
 
 REM --------- Quiet Detection ---------
 SET DK_QUIET=0


### PR DESCRIPTION
+ Change CI cached key location since mlfront-shell 2.4.2.6 is now XDG based
+ Notice about macOS build tool

+ mlfront-shell 2.4.2.7