### PR TITLE
Move cloning dk source into 010 script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Let's pretend your application is the [official ASCII art application for C# .NE
 
 **Instead** tell your users to run the following on Windows with PowerShell or in a macOS/Linux shell:
 
+<!-- Performed in 010-PROJECTROOT-README.md. mdx blocks must have `$ ` which interferes with GitHub copy-and-paste. -->
 <!-- $MDX skip -->
 ```console
 git clone --branch V2_4 https://github.com/diskuv/dk.git dksrc

--- a/maintenance/010-PROJECTROOT-README.sh
+++ b/maintenance/010-PROJECTROOT-README.sh
@@ -25,7 +25,10 @@ opam show mdx || opam install mdx
 #     install -v ../dksdk-coder/_build/default/ext/MlFront/src/MlFront_Exec/Shell.exe "$LOCALAPPDATA/Programs/dk0/dk0exe-2.4.2.12-windows_x86_64/mlfshell.exe"
 # fi
 
+# Clone dk source. First step in README.md.
 rm -rf dksrc/
+git clone --branch V2_4 https://github.com/diskuv/dk.git dksrc
+
 rm -rf 7zip-project/
 install -d 7zip-project
 set +f


### PR DESCRIPTION
This lets us use a normal "sh" code block that supports copy-and-paste in GitHub markdown